### PR TITLE
Fix Docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm ci
+RUN npm ci  --ignore-scripts
 
 # Copy source code
 COPY tsconfig.json ./
@@ -24,7 +24,7 @@ ENV NODE_ENV=production
 
 # Copy package files and install production dependencies
 COPY package*.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev --ignore-scripts
 
 # Copy built application from builder stage
 COPY --from=builder /app/dist ./dist


### PR DESCRIPTION
>docker build -t mcp-postgres-full-access .
[+] Building 4.4s (10/15)                                                                                                                                      docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                           0.0s
 => => transferring dockerfile: 829B                                                                                                                                           0.0s
 => [internal] load metadata for docker.io/library/node:20-alpine                                                                                                              1.3s
 => [auth] library/node:pull token for registry-1.docker.io                                                                                                                    0.0s
 => [internal] load .dockerignore                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                0.0s
 => [builder 1/7] FROM docker.io/library/node:20-alpine@sha256:c628bdc7ebc7f95b1b23249a445eb415ce68ae9def8b68364b35ee15e3065b0f                                                0.0s
 => => resolve docker.io/library/node:20-alpine@sha256:c628bdc7ebc7f95b1b23249a445eb415ce68ae9def8b68364b35ee15e3065b0f                                                        0.0s
 => [internal] load build context                                                                                                                                              0.0s
 => => transferring context: 391B                                                                                                                                              0.0s
 => CACHED [builder 2/7] WORKDIR /app                                                                                                                                          0.0s
 => CACHED [builder 3/7] COPY package*.json ./                                                                                                                                 0.0s
 => [release 4/6] RUN npm ci --omit=dev --ignore-scripts                                                                                                                       2.5s
 => ERROR [builder 4/7] RUN npm ci                      

Resolve: 
The key change is adding --ignore-scripts to the builder stage's npm ci command to prevent it from running the prepare script immediately.